### PR TITLE
Make container presets configurable

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -47,6 +47,14 @@ from simses.thermal import ThermostatStrategy, ThermostatMode
 from simses.thermal import SolarConfig, solar_heat_load
 ```
 
+### Thermal Container Presets
+
+```python
+from simses.model.thermal.containers import FortyFtContainer, TwentyFtContainer
+from simses.model.thermal.containers import AluminumLayer, SteelLayer
+from simses.model.thermal.containers import RockWoolLayer, PolyurethaneLayer
+```
+
 ### Cell Models
 
 ```python

--- a/docs/concepts/thermal.md
+++ b/docs/concepts/thermal.md
@@ -93,6 +93,15 @@ flowchart LR
 
 Each node has a lumped thermal capacity; each edge is a thermal resistance. Capacities are precomputed once from [`ContainerProperties`][simses.thermal.container.ContainerProperties] (length × width × height × material ρ × cₚ for walls and air); resistances combine half-layer conductive plus surface convection terms. Each `step(dt)` evaluates the five forward-Euler node equations using current-step temperatures only (explicit scheme — stable for realistic wall thicknesses and timesteps of a few seconds).
 
+Two ready-made presets are available as dataclass subclasses — [`FortyFtContainer`][simses.model.thermal.containers.FortyFtContainer] (12 m, rock-wool) and [`TwentyFtContainer`][simses.model.thermal.containers.TwentyFtContainer] (5.9 m, polyurethane). Instantiate them with no arguments for the defaults, or pass keyword arguments to override individual parameters:
+
+```python
+from simses.model.thermal.containers import FortyFtContainer
+
+props = FortyFtContainer()                  # all defaults
+props_less_air = FortyFtContainer(vol_air=0.7)   # 70 % of volume is air (rest is rack hardware)
+```
+
 The internal-air balance is the most useful node to reason about, since it's where HVAC lands and what the thermostat tracks:
 
 $$

--- a/src/simses/model/thermal/containers.py
+++ b/src/simses/model/thermal/containers.py
@@ -1,58 +1,83 @@
 """Predefined ContainerProperties instances for common shipping container sizes."""
 
+from dataclasses import dataclass, field
+
 from simses.thermal.container import ContainerLayer, ContainerProperties
 
 # ---------------------------------------------------------------------------
 # Shared wall layers
 # ---------------------------------------------------------------------------
-_INNER_AL = ContainerLayer(
-    thickness=0.001,  # m
-    conductivity=237.0,  # W/mK
-    density=2700.0,  # kg/m³
-    specific_heat=910.0,  # J/kgK
-)
 
-_OUTER_STEEL = ContainerLayer(
-    thickness=0.0016,  # m
-    conductivity=14.4,  # W/mK
-    density=8050.0,  # kg/m³
-    specific_heat=500.0,  # J/kgK
-)
+
+@dataclass(frozen=True)
+class AluminumLayer(ContainerLayer):
+    """Aluminum layer for container walls."""
+
+    thickness: float = 0.001  # m
+    conductivity: float = 237.0  # W/mK
+    density: float = 2700.0  # kg/m³
+    specific_heat: float = 910.0  # J/kgK
+
+
+@dataclass(frozen=True)
+class SteelLayer(ContainerLayer):
+    """Steel layer for container walls."""
+
+    thickness: float = 0.0016  # m
+    conductivity: float = 14.4  # W/mK
+    density: float = 8050.0  # kg/m³
+    specific_heat: float = 500.0  # J/kgK
+
+
+@dataclass(frozen=True)
+class RockWoolLayer(ContainerLayer):
+    """Rock-wool insulation layer for container walls."""
+
+    thickness: float = 0.050  # m
+    conductivity: float = 0.050  # W/mK
+    density: float = 100.0  # kg/m³
+    specific_heat: float = 840.0  # J/kgK
+
+
+@dataclass(frozen=True)
+class PolyurethaneLayer(ContainerLayer):
+    """Polyurethane insulation layer for container walls."""
+
+    thickness: float = 0.015  # m
+    conductivity: float = 0.022  # W/mK
+    density: float = 35.0  # kg/m³
+    specific_heat: float = 1400.0  # J/kgK
+
 
 # ---------------------------------------------------------------------------
 # 40-ft container  (rock-wool insulation)
 # ---------------------------------------------------------------------------
-FortyFtContainer = ContainerProperties(
-    length=12.0,  # m (internal)
-    width=2.3,  # m
-    height=2.35,  # m
-    h_inner=30.0,  # W/m²K
-    h_outer=30.0,  # W/m²K
-    inner=_INNER_AL,
-    mid=ContainerLayer(
-        thickness=0.050,  # m
-        conductivity=0.050,  # W/mK
-        density=100.0,  # kg/m³
-        specific_heat=840.0,  # J/kgK
-    ),
-    outer=_OUTER_STEEL,
-)
+@dataclass
+class FortyFtContainer(ContainerProperties):
+    """40-ft container with rock-wool insulation."""
+
+    length: float = 12.0  # m (internal)
+    width: float = 2.3  # m
+    height: float = 2.35  # m
+    h_inner: float = 30.0  # W/m²K
+    h_outer: float = 30.0  # W/m²K
+    inner: ContainerLayer = field(default_factory=AluminumLayer)
+    mid: ContainerLayer = field(default_factory=RockWoolLayer)
+    outer: ContainerLayer = field(default_factory=SteelLayer)
+
 
 # ---------------------------------------------------------------------------
 # 20-ft container  (polyurethane insulation)
 # ---------------------------------------------------------------------------
-TwentyFtContainer = ContainerProperties(
-    length=5.9,  # m (internal)
-    width=2.3,  # m
-    height=2.35,  # m
-    h_inner=30.0,  # W/m²K
-    h_outer=30.0,  # W/m²K
-    inner=_INNER_AL,
-    mid=ContainerLayer(
-        thickness=0.015,  # m
-        conductivity=0.022,  # W/mK
-        density=35.0,  # kg/m³
-        specific_heat=1400.0,  # J/kgK
-    ),
-    outer=_OUTER_STEEL,
-)
+@dataclass
+class TwentyFtContainer(ContainerProperties):
+    """20-ft container with polyurethane insulation."""
+
+    length: float = 5.9  # m (internal)
+    width: float = 2.3  # m
+    height: float = 2.35  # m
+    h_inner: float = 30.0  # W/m²K
+    h_outer: float = 30.0  # W/m²K
+    inner: ContainerLayer = field(default_factory=AluminumLayer)
+    mid: ContainerLayer = field(default_factory=PolyurethaneLayer)
+    outer: ContainerLayer = field(default_factory=SteelLayer)

--- a/tests/test_thermal_container.py
+++ b/tests/test_thermal_container.py
@@ -75,15 +75,15 @@ class TestContainerProperties:
     def test_forty_ft_A_surface_sanity(self):
         # 2*(12*2.3 + 12*2.35 + 2.3*2.35) = 2*(27.6 + 28.2 + 5.405) = 2*61.205 ≈ 122.41
         # expect > 100
-        assert FortyFtContainer.A_surface > 100.0
+        assert FortyFtContainer().A_surface > 100.0
 
     def test_forty_ft_V_internal(self):
         expected = 12.0 * 2.3 * 2.35
-        assert FortyFtContainer.V_internal == pytest.approx(expected)
+        assert FortyFtContainer().V_internal == pytest.approx(expected)
 
     def test_twenty_ft_smaller_than_forty_ft(self):
-        assert TwentyFtContainer.A_surface < FortyFtContainer.A_surface
-        assert TwentyFtContainer.V_internal < FortyFtContainer.V_internal
+        assert TwentyFtContainer().A_surface < FortyFtContainer().A_surface
+        assert TwentyFtContainer().V_internal < FortyFtContainer().V_internal
 
 
 # ===================================================================
@@ -215,7 +215,7 @@ class TestContainerThermalModelUnit:
         """
         from simses.model.thermal.containers import FortyFtContainer
 
-        model = _make_model(properties=FortyFtContainer, T_ambient=-23.0, T_initial=77.0)
+        model = _make_model(properties=FortyFtContainer(), T_ambient=-23.0, T_initial=77.0)
         T_in_before = 350.0
         for _ in range(300):
             model.step(dt=1.0)
@@ -304,7 +304,7 @@ class TestContainerThermalModelIntegration:
         limit (τ_air ≈ 21 s for a 40-ft container).
         """
         bat = _make_battery(T=25.0, soc=0.5)
-        model = _make_model(properties=FortyFtContainer)
+        model = _make_model(properties=FortyFtContainer())
         model.add_component(bat)
 
         for _ in range(100):
@@ -328,7 +328,7 @@ class TestContainerThermalModelIntegration:
 
     def test_forty_ft_container_runs_without_error(self):
         bat = _make_battery(T=25.0, soc=0.5)
-        model = _make_model(properties=FortyFtContainer)
+        model = _make_model(properties=FortyFtContainer())
         model.add_component(bat)
         for _ in range(5):
             bat.step(power_setpoint=500.0, dt=60.0)
@@ -336,7 +336,7 @@ class TestContainerThermalModelIntegration:
 
     def test_twenty_ft_container_runs_without_error(self):
         bat = _make_battery(T=25.0, soc=0.5)
-        model = _make_model(properties=TwentyFtContainer)
+        model = _make_model(properties=TwentyFtContainer())
         model.add_component(bat)
         for _ in range(5):
             bat.step(power_setpoint=500.0, dt=60.0)
@@ -345,7 +345,7 @@ class TestContainerThermalModelIntegration:
     def test_100_steps_physical_temperature_bounds(self):
         """Over 100 steps at dt=1 s, all temperatures remain physically plausible (-100–200 °C)."""
         bat = _make_battery(T=25.0, soc=0.5)
-        model = _make_model(properties=FortyFtContainer)
+        model = _make_model(properties=FortyFtContainer())
         model.add_component(bat)
 
         for _ in range(100):


### PR DESCRIPTION
This PR makes `FortyFtContainer` and `TwentyFtContainer` configurable data classes, allowing defaults to be overwritten. Same treatment for the predefined `ContainerLayer`s