### PR TITLE
Add Gasper LFP and NMC-B1 degradation models

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -72,6 +72,22 @@ Concrete implementations of cell, converter, degradation, and thermal models.
 
 ::: simses.model.degradation.sony_lfp_cyclic.SonyLFPCyclicDegradation
 
+### Gasper LFP|Gr Calendar Degradation
+
+::: simses.model.degradation.gasper_lfp_gr_calendar.GasperLFPGrCalendar
+
+### Gasper LFP|Gr Cyclic Degradation
+
+::: simses.model.degradation.gasper_lfp_gr_cyclic.GasperLFPGrCyclic
+
+### Gasper NMC|Gr B1 Calendar Degradation
+
+::: simses.model.degradation.gasper_nmc_gr_b1_calendar.GasperNMCGrB1Calendar
+
+### Gasper NMC|Gr B1 Cyclic Degradation
+
+::: simses.model.degradation.gasper_nmc_gr_b1_cyclic.GasperNMCGrB1Cyclic
+
 ## Thermal Container Presets
 
 ::: simses.model.thermal.containers

--- a/docs/guides/aging-models.md
+++ b/docs/guides/aging-models.md
@@ -1,0 +1,121 @@
+# Choosing an Aging Model
+
+simses ships three (calendar, cyclic) aging model pairs today, each fitted to a specific commercial cell. The table below is the quick chooser; each pair is then documented in its own section with its underlying source, tested stressor envelope, and composition example.
+
+!!! info "Who this is for"
+    Users running multi-year studies where aging matters. Aging in simses is a **choice** — the electrical cell model and the aging model are composed independently, so you can pair any degradation pair with any `CellType` that shares the same chemistry family. For the framework itself, see [Degradation](../concepts/degradation.md).
+
+## Comparison
+
+| Pair | Chemistry | Tested cell | Format | Capacity | Trained DoD (cycling) | Trained T (cycling) | Ships as default of |
+|---|---|---|---|---|---|---|---|
+| [Naumann](#naumann-sony-lfp) | LFP | Sony US26650FTC1 | Cylindrical 26650 | 3 Ah | 10 – 90 % | 0 – 60 °C | `SonyLFP` |
+| [Gasper LFP&#124;Gr](#gasper-lfpgr) | LFP (large-format) | Anonymised, ~2019 vintage | Prismatic | 250 Ah | 80 – 100 % | 10 – 45 °C | — (compose explicitly) |
+| [Gasper NMC&#124;Gr B1](#gasper-nmcgr-b1) | NMC (large-format) | Anonymised, ~2020 vintage | Pouch | 50 Ah | 80 – 100 % | 10 – 45 °C | — (compose explicitly) |
+
+All three pairs share simses's [`CalendarDegradation`][simses.degradation.calendar.CalendarDegradation] + [`CyclicDegradation`][simses.degradation.cyclic.CyclicDegradation] Protocol interface, so they slot interchangeably into a [`DegradationModel`][simses.degradation.degradation.DegradationModel].
+
+## Naumann (Sony LFP)
+
+The default aging pair shipped with `SonyLFP`. Semi-empirical fits to accelerated-aging tests on the Sony/Murata US26650FTC1 3 Ah cylindrical LFP cell:
+
+- **Calendar** — √t stress-factor with Arrhenius temperature dependence and a cubic SOC term.
+- **Cyclic** — √FEC stress-factor with a cubic DoD term and a linear C-rate term.
+
+Both use exact virtual-time / virtual-FEC continuation so they stay correct under varying operating conditions. Best-suited to small-format cylindrical LFP and to any study where you want simses's ready-made "aging on" behaviour via `Battery(..., degradation=True)`. See [Degradation concept](../concepts/degradation.md#concrete-example-sony-lfp-calendar-aging-naumann-2018) for the worked walkthrough.
+
+Sources: Naumann et al., [*J. Energy Storage* 17 (2018)](https://doi.org/10.1016/j.est.2018.01.019); [*J. Power Sources* 451 (2020)](https://doi.org/10.1016/j.jpowsour.2019.227666).
+
+```python
+from simses.battery import Battery
+from simses.model.cell.sony_lfp import SonyLFP
+
+battery = Battery(
+    cell=SonyLFP(),
+    circuit=(13, 1),
+    initial_states={"start_soc": 0.5, "start_T": 25.0},
+    degradation=True,                     # picks up the Naumann pair automatically
+)
+```
+
+## Gasper LFP&#124;Gr
+
+A large-format prismatic LFP capacity-fade model from Gasper et al. 2023 ([*J. Energy Storage* 73, 109042](https://doi.org/10.1016/j.est.2023.109042)), ported one-to-one from NREL's [BLAST-Lite](https://github.com/NREL/BLAST-Lite). Semi-empirical: an Arrhenius calendar term with anode-potential SoC dependence, and a low-order semi-empirical cyclic term. Behaves cleanly across the full DoD range (LFP chemistry is intrinsically DoD-insensitive in this fit).
+
+!!! warning "Applicability caveat"
+    The fit corresponds to a specific ~2019-vintage 250 Ah prismatic LFP cell (anonymised in the paper). Modern (2023 +) large-format LFP cells for stationary storage — CATL LF280K, EVE LF280K, BYD blade — typically show **2 – 3× longer cycle life** and comparable calendar life. Treat quantitative EOL predictions from this model as **conservative lower bounds**. The *shape* of the aging response (SoC / T / DoD / C-rate sensitivities) remains useful for aging-aware operation studies.
+
+!!! note "No resistance model"
+    Gasper et al. 2023 publishes capacity-fade equations only. `update_resistance()` returns 0 on both legs — `state.soh_R` stays at 1.0 for the whole simulation. If your study depends on resistance rise, combine with a separate resistance-only calendar or cyclic sub-model, or use the Naumann pair.
+
+**Recommended pairing.** Compose with the existing [`SonyLFP`](cell-models.md#sonylfp) electrical model as an LFP-chemistry proxy. OCV, hysteresis, and entropy are chemistry properties and transfer cleanly across cell formats; capacity is scaled to system level via `circuit=(s, p)`. Users who need a genuinely different capacity or a different R_int(SoC, T) map should subclass `SonyLFP` and override — see [Extending Cell Models](extending-cells.md).
+
+```python
+from simses.battery import Battery
+from simses.degradation import DegradationModel
+from simses.model.cell.sony_lfp import SonyLFP
+from simses.model.degradation.gasper_lfp_gr_calendar import GasperLFPGrCalendar
+from simses.model.degradation.gasper_lfp_gr_cyclic import GasperLFPGrCyclic
+
+battery = Battery(
+    cell=SonyLFP(),                              # LFP-chemistry electrical proxy
+    circuit=(1, 100),                            # scale to system size
+    initial_states={"start_soc": 0.5, "start_T": 25.0},
+    degradation=DegradationModel(
+        calendar=GasperLFPGrCalendar(),
+        cyclic=GasperLFPGrCyclic(),
+        initial_soc=0.5,
+    ),
+)
+```
+
+## Gasper NMC&#124;Gr B1
+
+A large-format pouch NMC capacity-fade model from the same Gasper et al. 2023 study. Compact single-term multiplicative power law in DoD, T, and C-rate — the simplest and best-behaved of the paper's four NMC chemistries. Monotonic in every stressor, no `abs()` clipping, extrapolates cleanly outside the [0.8, 1] DoD training band.
+
+!!! warning "Applicability caveat"
+    The fit corresponds to a specific ~2020-vintage 50 Ah pouch NMC|Gr cell (anonymised in the paper). Manufacturer-specific behaviour of modern large-format NMC|Gr cells will differ; treat quantitative EOL predictions from this model as approximate.
+
+!!! note "No resistance model"
+    Same as LFP|Gr — the Gasper paper publishes capacity fade only. `update_resistance()` returns 0 on both legs.
+
+**Recommended pairing.** Compose with the existing [`Samsung94AhNMC`](cell-models.md#samsung94ahnmc) electrical model as an NMC-chemistry proxy.
+
+```python
+from simses.battery import Battery
+from simses.degradation import DegradationModel
+from simses.model.cell.samsung94Ah_nmc import Samsung94AhNMC
+from simses.model.degradation.gasper_nmc_gr_b1_calendar import GasperNMCGrB1Calendar
+from simses.model.degradation.gasper_nmc_gr_b1_cyclic import GasperNMCGrB1Cyclic
+
+battery = Battery(
+    cell=Samsung94AhNMC(),                       # NMC-chemistry electrical proxy
+    circuit=(96, 1),
+    initial_states={"start_soc": 0.5, "start_T": 25.0},
+    degradation=DegradationModel(
+        calendar=GasperNMCGrB1Calendar(),
+        cyclic=GasperNMCGrB1Cyclic(),
+        initial_soc=0.5,
+    ),
+)
+```
+
+## Why "electrical model as a chemistry proxy"?
+
+The Gasper cells in the paper are anonymised — the authors publish the aging fits but not the OCV curves, R_int maps, hysteresis, thermal properties, or mass. Building dedicated `GasperLFPGrCell` / `GasperNMCGrB1Cell` classes would require inventing values for everything except capacity, nominal voltage, and a single scalar DCIR from Table 1 of the paper. simses deliberately avoids that: the aging model is exported as a pair of Protocol implementations, and users pair it with whichever electrical cell model most closely matches the chemistry of interest.
+
+The physical rationale is that **OCV(SoC), hysteresis, and entropy are chemistry properties** — they're a function of the electrode materials, not of the cell format. The LFP OCV plateau near 3.3 V, the entropic-coefficient signature, the small hysteresis at 50 % SOC — all of these transfer cleanly from a 3 Ah Sony cylindrical to a 250 Ah prismatic LFP cell of the same chemistry family. What *doesn't* transfer is R_int in Ohms (scales with capacity and format), max C-rates, thermal mass, and cell format geometry. If any of those matter to your study, subclass the electrical cell class and override the relevant properties.
+
+## Attribution
+
+The two Gasper pairs are ported from NREL's [BLAST-Lite](https://github.com/NREL/BLAST-Lite) Python library (BSD-3-Clause). Original implementations by Paul Gasper (NREL). Each ported file preserves the BLAST-Lite license notice in-file as required by BSD-3.
+
+## Extending
+
+To add a new aging model — either a fresh fit or a refit of an existing functional form against your own data — see [Extending Degradation](extending-degradation.md).
+
+## See Also
+
+- [Degradation concept](../concepts/degradation.md) — SoH axes, running totals, virtual-time continuation.
+- [Choosing a Cell Model](cell-models.md) — electrical models recommended for pairing with the aging pairs above.
+- [Models API reference](../api/models.md) — the shipped degradation model classes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - User Guides:
       - Installation: guides/installation.md
       - Choosing a Cell Model: guides/cell-models.md
+      - Choosing an Aging Model: guides/aging-models.md
       - Choosing a Converter Model: guides/converter-models.md
       - Multi-String Systems: guides/multi-string.md
       - Logging and Plots: guides/logging-and-plots.md

--- a/src/simses/model/degradation/gasper_common.py
+++ b/src/simses/model/degradation/gasper_common.py
@@ -1,0 +1,128 @@
+"""Shared helpers for the Gasper et al. (2023) family of degradation models.
+
+This module hosts code that is reused by every ``gasper_*_calendar.py`` and
+``gasper_*_cyclic.py`` module: the anode-potential function ``ua_from_soc``
+(ported from BLAST-Lite, in turn derived from Safari & Delacourt, 2011) and
+the closed-form power-law continuation helper ``power_law_continuation``
+used to translate BLAST-Lite's offline ``q = k * x**p`` aggregation into
+simses's per-step incremental ``CalendarDegradation`` / ``CyclicDegradation``
+Protocol API.
+
+The ``ua_from_soc`` function is ported from NREL/BLAST-Lite and is
+distributed under the BSD-3-Clause license reproduced at the bottom of this
+file. The continuation helper is original to simses and is covered by the
+project license.
+
+Original BLAST-Lite source:
+    https://github.com/NREL/BLAST-Lite/blob/main/blast/models/degradation_model.py
+Underlying paper:
+    Gasper et al., "Degradation and modeling of large-format commercial
+    lithium-ion cells as a function of chemistry, design, and aging
+    conditions", J. Energy Storage 73 (2023) 109042.
+    DOI: https://doi.org/10.1016/j.est.2023.109042
+"""
+
+import math
+
+# ---------------------------------------------------------------------------
+# Shared functions
+# ---------------------------------------------------------------------------
+
+# Reference anode potential at ~50% SOC; used to normalise Ua in the NMC|Gr
+# calendar models (see e.g. nmc_gr_75Ah_A_2019.py in BLAST-Lite).
+UA_REF = 0.123  # V
+
+# Reference temperature used by the NMC|Gr models' Arrhenius-style
+# normalisation (308.15 K = 35 °C).
+T_REF_K = 273.15 + 35.0  # K
+
+
+def ua_from_soc(soc: float) -> float:
+    """Return the graphite anode potential ``Ua`` (V) for a given cell SOC.
+
+    Implements the closed-form approximation used throughout Gasper et al.
+    (2023) and BLAST-Lite: the lithiation fraction ``xa`` is linear in SOC,
+    and ``Ua`` is a sum of one decaying exponential and four ``tanh`` terms
+    plus a constant. Originally from Safari & Delacourt (2011).
+
+    Args:
+        soc: Cell state of charge in p.u. (0 to 1).
+
+    Returns:
+        Anode potential vs. Li/Li+ in volts.
+    """
+    xa = 8.5e-3 + soc * (0.78 - 8.5e-3)
+    return (
+        0.6379
+        + 0.5416 * math.exp(-305.5309 * xa)
+        + 0.044 * math.tanh(-(xa - 0.1958) / 0.1088)
+        - 0.1978 * math.tanh((xa - 1.0571) / 0.0854)
+        - 0.6875 * math.tanh((xa + 0.0117) / 0.0529)
+        - 0.0175 * math.tanh((xa - 0.5692) / 0.0875)
+    )
+
+
+def power_law_continuation(k: float, accumulated_qloss: float, dx: float, p: float) -> float:
+    """Return the incremental qloss for one step of a ``qloss = k * x**p`` trajectory.
+
+    Uses *virtual-x continuation*: the accumulated qloss is inverted to find
+    the equivalent ``x_virtual`` already "spent" on the current trajectory,
+    the trajectory is advanced by ``dx``, and the new qloss is differenced
+    against the accumulated value. This is exact (no linearisation error)
+    and mirrors the pattern used by the existing Sony LFP Naumann models.
+
+    Args:
+        k: Stress-factor prefactor of the trajectory (instantaneous).
+        accumulated_qloss: qloss accumulated on this trajectory so far (p.u.).
+        dx: Increment of the independent variable for this step
+            (days for calendar, EFC for cyclic; pre-scaled by the model's
+            normalisation factor if any).
+        p: Power-law exponent.
+
+    Returns:
+        ``delta_qloss`` (p.u.) to add to ``accumulated_qloss`` this step.
+    """
+    if k <= 0.0 or dx == 0.0:
+        return 0.0
+    if accumulated_qloss <= 0.0:
+        return k * dx**p
+    virtual_x = (accumulated_qloss / k) ** (1.0 / p)
+    return k * (virtual_x + dx) ** p - accumulated_qloss
+
+
+# ---------------------------------------------------------------------------
+# Attribution and license of the BLAST-Lite code ported above
+# ---------------------------------------------------------------------------
+#
+# The ``ua_from_soc`` function is a one-to-one port of the static
+# ``_get_Ua`` method of BLAST-Lite's ``BatteryDegradationModel`` base class.
+# Original implementation: Paul Gasper (NREL).
+#
+# Copyright (c) 2023, Alliance for Energy Innovation, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/simses/model/degradation/gasper_lfp_gr_calendar.py
+++ b/src/simses/model/degradation/gasper_lfp_gr_calendar.py
@@ -1,0 +1,110 @@
+"""Calendar degradation model for the Gasper et al. (2023) LFP|Gr cell.
+
+Ported from NREL/BLAST-Lite:
+    https://github.com/NREL/BLAST-Lite/blob/main/blast/models/lfp_gr_250AhPrismatic_2019.py
+Original author: Paul Gasper (NREL).
+
+Underlying model: Gasper et al., "Degradation and modeling of large-format
+commercial lithium-ion cells as a function of chemistry, design, and aging
+conditions", J. Energy Storage 73 (2023) 109042.
+DOI: https://doi.org/10.1016/j.est.2023.109042 — see Appendix A.7 / Table A.4
+(semi-empirical reduced-order capacity-fade model for 'LFP|Gr'). The paper
+itself selects the semi-empirical fit over the ML one for this cell
+(Section 3.4 / Table 3: lower MAPE, higher R²adjusted), and BLAST-Lite
+follows that choice; we follow BLAST-Lite as the authoritative implementation.
+
+The mathematics and coefficients below are reproduced one-to-one from
+BLAST-Lite. The class is rewired to simses's stateless per-step
+``CalendarDegradation`` Protocol API and uses an exact virtual-time
+continuation of the underlying ``q = k_cal * t_days**pcal`` trajectory
+(LFP|Gr applies no time normalisation, unlike the NMC|Gr variants).
+
+BLAST-Lite is distributed under BSD-3-Clause; the license text is reproduced
+at the bottom of this file as required by the copyright notice.
+
+The Gasper et al. paper publishes capacity-fade equations only; no
+resistance-rise model is provided. ``update_resistance`` therefore returns 0.
+
+Applicability note
+------------------
+The fit corresponds to a specific ~2019-vintage 250 Ah prismatic LFP cell.
+Modern (2023+) large-format LFP cells for stationary storage — e.g. CATL
+LF280K, EVE LF280K, BYD blade — typically show 2–3× longer cycle life and
+comparable calendar life. Treat quantitative EOL predictions from this
+model as conservative lower bounds. The *shape* of the aging response
+(SoC / T / DoD / C-rate sensitivities) remains a useful reference for
+aging-aware operation studies.
+"""
+
+import math
+
+from simses.battery.state import BatteryState
+from simses.degradation.calendar import CalendarDegradation
+from simses.model.degradation.gasper_common import power_law_continuation, ua_from_soc
+
+# Coefficients from BLAST-Lite (lfp_gr_250AhPrismatic_2019.py / paper Table A.4).
+P1 = 8.37e4
+P2 = -5.21e3
+P3 = -3.56e3
+PCAL = 0.526
+
+# No time normalisation for LFP|Gr (BLAST-Lite passes delta_t_days directly).
+TIME_SCALE_DAYS = 1.0
+
+
+class GasperLFPGrCalendar(CalendarDegradation):
+    """Calendar aging for the Gasper et al. 'LFP|Gr' cell (~250 Ah prismatic).
+
+    Stateless: virtual-time continuation is driven by ``accumulated_qloss``
+    passed in by :class:`~simses.degradation.degradation.DegradationModel`.
+    """
+
+    def update_capacity(self, state: BatteryState, dt: float, accumulated_qloss: float) -> float:
+        if dt == 0.0:
+            return 0.0
+
+        TdegK = state.T + 273.15
+        Ua = ua_from_soc(state.soc)
+
+        kcal = abs(P1) * math.exp(P2 / TdegK) * math.exp(P3 * Ua / TdegK)
+
+        dt_days_scaled = (dt / 86400.0) / TIME_SCALE_DAYS
+        return power_law_continuation(kcal, accumulated_qloss, dt_days_scaled, PCAL)
+
+    def update_resistance(self, state: BatteryState, dt: float) -> float:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# BLAST-Lite BSD-3-Clause license (verbatim, as required by the BSD-3
+# clauses governing the redistribution of the ported model code above).
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2023, Alliance for Energy Innovation, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/simses/model/degradation/gasper_lfp_gr_cyclic.py
+++ b/src/simses/model/degradation/gasper_lfp_gr_cyclic.py
@@ -1,0 +1,117 @@
+"""Cyclic degradation model for the Gasper et al. (2023) LFP|Gr cell.
+
+Ported from NREL/BLAST-Lite:
+    https://github.com/NREL/BLAST-Lite/blob/main/blast/models/lfp_gr_250AhPrismatic_2019.py
+Original author: Paul Gasper (NREL).
+
+Underlying model: Gasper et al., "Degradation and modeling of large-format
+commercial lithium-ion cells as a function of chemistry, design, and aging
+conditions", J. Energy Storage 73 (2023) 109042.
+DOI: https://doi.org/10.1016/j.est.2023.109042 — see Appendix A.7 / Table A.5
+(semi-empirical reduced-order capacity-fade model for 'LFP|Gr'). The paper
+itself selects the semi-empirical fit over the ML one for this cell
+(Section 3.4 / Table 3: lower MAPE, higher R²adjusted), and BLAST-Lite
+follows that choice; we follow BLAST-Lite as the authoritative implementation.
+
+The mathematics and coefficients below are reproduced one-to-one from
+BLAST-Lite. The class is rewired to simses's stateless per-half-cycle
+``CyclicDegradation`` Protocol API and uses an exact virtual-FEC
+continuation of the underlying ``q = k_cyc * EFC**pcyc`` trajectory
+(LFP|Gr applies no FEC normalisation, unlike the NMC|Gr variants).
+
+BLAST-Lite is distributed under BSD-3-Clause; the license text is reproduced
+at the bottom of this file as required by the copyright notice.
+
+The Gasper et al. paper publishes capacity-fade equations only; no
+resistance-rise model is provided. ``update_resistance`` therefore returns 0.
+
+Applicability note
+------------------
+The fit corresponds to a specific ~2019-vintage 250 Ah prismatic LFP cell.
+Modern (2023+) large-format LFP cells for stationary storage — e.g. CATL
+LF280K, EVE LF280K, BYD blade — typically show 2–3× longer cycle life and
+comparable calendar life. Treat quantitative EOL predictions from this
+model as conservative lower bounds. The *shape* of the aging response
+(SoC / T / DoD / C-rate sensitivities) remains a useful reference for
+aging-aware operation studies.
+"""
+
+import math
+
+from simses.battery.state import BatteryState
+from simses.degradation.cycle_detector import HalfCycle
+from simses.degradation.cyclic import CyclicDegradation
+from simses.model.degradation.gasper_common import power_law_continuation
+
+# Coefficients from BLAST-Lite (lfp_gr_250AhPrismatic_2019.py / paper Table A.5).
+P4 = 4.38e-8
+P5 = 1.55e-8
+P6 = 1.68e-7
+P7 = 2.19e3
+P8 = 1.55e5
+PCYC = 0.828
+
+# No FEC normalisation for LFP|Gr (BLAST-Lite passes delta_efc directly).
+EFC_SCALE = 1.0
+
+
+class GasperLFPGrCyclic(CyclicDegradation):
+    """Cyclic aging for the Gasper et al. 'LFP|Gr' cell (~250 Ah prismatic).
+
+    Stateless: virtual-FEC continuation is driven by ``accumulated_qloss``
+    passed in by :class:`~simses.degradation.degradation.DegradationModel`.
+    Temperature is sampled instantaneously from ``state.T`` at the moment
+    the half-cycle completes; DoD, C-rate and FEC come from ``half_cycle``.
+    """
+
+    def update_capacity(self, state: BatteryState, half_cycle: HalfCycle, accumulated_qloss: float) -> float:
+        delta_efc = half_cycle.full_equivalent_cycles
+        if delta_efc == 0.0:
+            return 0.0
+
+        TdegK = state.T + 273.15
+        dod = half_cycle.depth_of_discharge
+        crate = half_cycle.c_rate
+
+        kcyc = (P4 + P5 * dod + P6 * crate) * (math.exp(P7 / TdegK) + math.exp(-P8 / TdegK))
+
+        delta_efc_scaled = delta_efc / EFC_SCALE
+        return power_law_continuation(kcyc, accumulated_qloss, delta_efc_scaled, PCYC)
+
+    def update_resistance(self, state: BatteryState, half_cycle: HalfCycle) -> float:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# BLAST-Lite BSD-3-Clause license (verbatim, as required by the BSD-3
+# clauses governing the redistribution of the ported model code above).
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2023, Alliance for Energy Innovation, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/simses/model/degradation/gasper_nmc_gr_b1_calendar.py
+++ b/src/simses/model/degradation/gasper_nmc_gr_b1_calendar.py
@@ -1,0 +1,110 @@
+"""Calendar degradation model for the Gasper et al. (2023) NMC|Gr B1 cell.
+
+Ported from NREL/BLAST-Lite:
+    https://github.com/NREL/BLAST-Lite/blob/main/blast/models/nmc_gr_50Ah_B1_2020.py
+Original author: Paul Gasper (NREL).
+
+Underlying model: Gasper et al., "Degradation and modeling of large-format
+commercial lithium-ion cells as a function of chemistry, design, and aging
+conditions", J. Energy Storage 73 (2023) 109042.
+DOI: https://doi.org/10.1016/j.est.2023.109042 — see Appendix A.8 (ML model
+for 'NMC|Gr B1').
+
+The mathematics and coefficients below are reproduced one-to-one from
+BLAST-Lite. The class is rewired to simses's stateless per-step
+``CalendarDegradation`` Protocol API and uses an exact virtual-time
+continuation of the underlying ``q = k_cal * (t/1e4d)**pcal`` trajectory.
+
+BLAST-Lite is distributed under BSD-3-Clause; the license text is reproduced
+at the bottom of this file as required by the copyright notice.
+
+The Gasper et al. paper publishes capacity-fade equations only; no
+resistance-rise model is provided. ``update_resistance`` therefore returns 0.
+
+Applicability note
+------------------
+The fit corresponds to a specific ~2020-vintage 50 Ah pouch NMC|Gr cell
+(anonymised in the paper). Manufacturer-specific behaviour of modern
+large-format NMC|Gr cells will differ; treat quantitative EOL predictions
+from this model as approximate. Of the four NMC|Gr chemistries in Gasper
+et al. its single-term power-law form extrapolates cleanly outside the
+[0.8, 1] DoD training band.
+"""
+
+import math
+
+from simses.battery.state import BatteryState
+from simses.degradation.calendar import CalendarDegradation
+from simses.model.degradation.gasper_common import (
+    T_REF_K,
+    UA_REF,
+    power_law_continuation,
+    ua_from_soc,
+)
+
+# Coefficients from BLAST-Lite (nmc_gr_50Ah_B1_2020.py / paper Table A.8).
+P1 = 36.2
+P2 = -4.4
+PCAL = 0.708
+
+# Power-law normalisation: q = k_cal * (t_days / TIME_SCALE_DAYS)**PCAL.
+TIME_SCALE_DAYS = 1e4
+
+
+class GasperNMCGrB1Calendar(CalendarDegradation):
+    """Calendar aging for the Gasper et al. 'NMC|Gr B1' cell (50 Ah pouch).
+
+    Stateless: virtual-time continuation is driven by ``accumulated_qloss``
+    passed in by :class:`~simses.degradation.degradation.DegradationModel`.
+    """
+
+    def update_capacity(self, state: BatteryState, dt: float, accumulated_qloss: float) -> float:
+        if dt == 0.0:
+            return 0.0
+
+        TdegK = state.T + 273.15
+        TdegKN = TdegK / T_REF_K
+        UaN = ua_from_soc(state.soc) / UA_REF
+
+        kcal = P1 * math.exp(P2 * (1.0 / (TdegKN**3)) * (UaN ** (1.0 / 3.0)))
+
+        dt_days_scaled = (dt / 86400.0) / TIME_SCALE_DAYS
+        return power_law_continuation(kcal, accumulated_qloss, dt_days_scaled, PCAL)
+
+    def update_resistance(self, state: BatteryState, dt: float) -> float:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# BLAST-Lite BSD-3-Clause license (verbatim, as required by the BSD-3
+# clauses governing the redistribution of the ported model code above).
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2023, Alliance for Energy Innovation, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/simses/model/degradation/gasper_nmc_gr_b1_cyclic.py
+++ b/src/simses/model/degradation/gasper_nmc_gr_b1_cyclic.py
@@ -1,0 +1,109 @@
+"""Cyclic degradation model for the Gasper et al. (2023) NMC|Gr B1 cell.
+
+Ported from NREL/BLAST-Lite:
+    https://github.com/NREL/BLAST-Lite/blob/main/blast/models/nmc_gr_50Ah_B1_2020.py
+Original author: Paul Gasper (NREL).
+
+Underlying model: Gasper et al., "Degradation and modeling of large-format
+commercial lithium-ion cells as a function of chemistry, design, and aging
+conditions", J. Energy Storage 73 (2023) 109042.
+DOI: https://doi.org/10.1016/j.est.2023.109042 — see Appendix A.8 (ML model
+for 'NMC|Gr B1').
+
+The mathematics and coefficients below are reproduced one-to-one from
+BLAST-Lite. The class is rewired to simses's stateless per-half-cycle
+``CyclicDegradation`` Protocol API and uses an exact virtual-FEC
+continuation of the underlying ``q = k_cyc * (EFC/1e5)**pcyc`` trajectory.
+
+BLAST-Lite is distributed under BSD-3-Clause; the license text is reproduced
+at the bottom of this file as required by the copyright notice.
+
+The Gasper et al. paper publishes capacity-fade equations only; no
+resistance-rise model is provided. ``update_resistance`` therefore returns 0.
+
+Applicability note
+------------------
+The fit corresponds to a specific ~2020-vintage 50 Ah pouch NMC|Gr cell
+(anonymised in the paper). Manufacturer-specific behaviour of modern
+large-format NMC|Gr cells will differ; treat quantitative EOL predictions
+from this model as approximate. Of the four NMC|Gr chemistries in Gasper
+et al. its single-term power-law form extrapolates cleanly outside the
+[0.8, 1] DoD training band.
+"""
+
+import math
+
+from simses.battery.state import BatteryState
+from simses.degradation.cycle_detector import HalfCycle
+from simses.degradation.cyclic import CyclicDegradation
+from simses.model.degradation.gasper_common import T_REF_K, power_law_continuation
+
+# Coefficients from BLAST-Lite (nmc_gr_50Ah_B1_2020.py / paper Table A.8).
+P3 = 0.844
+P4 = 0.458
+PCYC = 0.467
+
+# Power-law normalisation: q = k_cyc * (EFC / EFC_SCALE)**PCYC.
+EFC_SCALE = 1e5
+
+
+class GasperNMCGrB1Cyclic(CyclicDegradation):
+    """Cyclic aging for the Gasper et al. 'NMC|Gr B1' cell (50 Ah pouch).
+
+    Stateless: virtual-FEC continuation is driven by ``accumulated_qloss``
+    passed in by :class:`~simses.degradation.degradation.DegradationModel`.
+    Temperature is sampled instantaneously from ``state.T`` at the moment
+    the half-cycle completes; DoD, C-rate and FEC come from ``half_cycle``.
+    """
+
+    def update_capacity(self, state: BatteryState, half_cycle: HalfCycle, accumulated_qloss: float) -> float:
+        delta_efc = half_cycle.full_equivalent_cycles
+        if delta_efc == 0.0:
+            return 0.0
+
+        TdegKN = (state.T + 273.15) / T_REF_K
+        dod = half_cycle.depth_of_discharge
+        crate = half_cycle.c_rate
+
+        kcyc = abs(P3 * ((dod**2) * (TdegKN**3) * math.sqrt(crate)) ** P4)
+
+        delta_efc_scaled = delta_efc / EFC_SCALE
+        return power_law_continuation(kcyc, accumulated_qloss, delta_efc_scaled, PCYC)
+
+    def update_resistance(self, state: BatteryState, half_cycle: HalfCycle) -> float:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# BLAST-Lite BSD-3-Clause license (verbatim, as required by the BSD-3
+# clauses governing the redistribution of the ported model code above).
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2023, Alliance for Energy Innovation, LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/test_degradation_models.py
+++ b/tests/test_degradation_models.py
@@ -11,6 +11,10 @@ import pytest
 
 from simses.battery.state import BatteryState
 from simses.degradation.cycle_detector import HalfCycle
+from simses.model.degradation.gasper_lfp_gr_calendar import GasperLFPGrCalendar
+from simses.model.degradation.gasper_lfp_gr_cyclic import GasperLFPGrCyclic
+from simses.model.degradation.gasper_nmc_gr_b1_calendar import GasperNMCGrB1Calendar
+from simses.model.degradation.gasper_nmc_gr_b1_cyclic import GasperNMCGrB1Cyclic
 from simses.model.degradation.sony_lfp_calendar import SonyLFPCalendarDegradation
 from simses.model.degradation.sony_lfp_cyclic import SonyLFPCyclicDegradation
 
@@ -56,10 +60,13 @@ def _make_half_cycle(dod: float = 0.5, mean_soc: float = 0.5, c_rate: float = 0.
 class CalendarModelSpec:
     name: str
     factory: type
+    models_resistance: bool = True  # set False for capacity-fade-only models
 
 
 CALENDAR_SPECS = [
     CalendarModelSpec(name="SonyLFPCalendar", factory=SonyLFPCalendarDegradation),
+    CalendarModelSpec(name="GasperLFPGrCalendar", factory=GasperLFPGrCalendar, models_resistance=False),
+    CalendarModelSpec(name="GasperNMCGrB1Calendar", factory=GasperNMCGrB1Calendar, models_resistance=False),
 ]
 
 
@@ -67,10 +74,13 @@ CALENDAR_SPECS = [
 class CyclicModelSpec:
     name: str
     factory: type
+    models_resistance: bool = True  # set False for capacity-fade-only models
 
 
 CYCLIC_SPECS = [
     CyclicModelSpec(name="SonyLFPCyclic", factory=SonyLFPCyclicDegradation),
+    CyclicModelSpec(name="GasperLFPGrCyclic", factory=GasperLFPGrCyclic, models_resistance=False),
+    CyclicModelSpec(name="GasperNMCGrB1Cyclic", factory=GasperNMCGrB1Cyclic, models_resistance=False),
 ]
 
 
@@ -107,8 +117,14 @@ class TestCalendarModel:
         dq = cal_model.update_capacity(state, dt=3600.0, accumulated_qloss=0.0)
         assert dq > 0
 
-    def test_delta_soh_r_positive(self, cal_model):
-        """Calendar aging should increase resistance (delta_soh_R > 0)."""
+    def test_delta_soh_r_positive(self, cal_model, cal_spec):
+        """Calendar aging should increase resistance (delta_soh_R > 0).
+
+        Capacity-fade-only models (e.g. the Gasper family) opt out via
+        ``models_resistance=False`` on their spec.
+        """
+        if not cal_spec.models_resistance:
+            pytest.skip(f"{cal_spec.name} does not model resistance increase")
         state = _make_state()
         dr = cal_model.update_resistance(state, dt=3600.0)
         assert dr > 0
@@ -141,8 +157,14 @@ class TestCyclicModel:
         dq = cyc_model.update_capacity(state, hc, accumulated_qloss=0.0)
         assert dq > 0
 
-    def test_delta_soh_r_positive(self, cyc_model):
-        """Cyclic aging should increase resistance (delta_soh_R > 0)."""
+    def test_delta_soh_r_positive(self, cyc_model, cyc_spec):
+        """Cyclic aging should increase resistance (delta_soh_R > 0).
+
+        Capacity-fade-only models (e.g. the Gasper family) opt out via
+        ``models_resistance=False`` on their spec.
+        """
+        if not cyc_spec.models_resistance:
+            pytest.skip(f"{cyc_spec.name} does not model resistance increase")
         state = _make_state()
         hc = _make_half_cycle()
         dr = cyc_model.update_resistance(state, hc)
@@ -278,3 +300,104 @@ class TestSonyLFPCyclic:
 
         assert dq_total == pytest.approx(dq_single, rel=0.02)
         assert dr_total == pytest.approx(dr_single, rel=0.02)
+
+
+# ===================================================================
+# Gasper family — shared behavioural tests across all 4 chemistries
+# ===================================================================
+# These tests apply to the four Gasper et al. (2023) cells ported from
+# NREL/BLAST-Lite. Generic positivity / zero-step / monotonic-in-time tests
+# are already covered by the parameterised registries above; the cases here
+# cover behaviours specific to the Gasper family (capacity-fade only,
+# expected T monotonicity for calendar, virtual-time/FEC continuity).
+
+GASPER_CALENDAR_FACTORIES = [
+    GasperLFPGrCalendar,
+    GasperNMCGrB1Calendar,
+]
+
+GASPER_CYCLIC_FACTORIES = [
+    GasperLFPGrCyclic,
+    GasperNMCGrB1Cyclic,
+]
+
+
+class TestGasperCalendarFamily:
+    @pytest.mark.parametrize("factory", GASPER_CALENDAR_FACTORIES, ids=lambda f: f.__name__)
+    def test_resistance_returns_zero(self, factory):
+        """Gasper models intentionally do not model resistance increase."""
+        model = factory()
+        assert model.update_resistance(_make_state(), dt=3600.0) == 0.0
+
+    @pytest.mark.parametrize("factory", GASPER_CALENDAR_FACTORIES, ids=lambda f: f.__name__)
+    def test_higher_temperature_more_aging(self, factory):
+        """All four Gasper calendar models accelerate with temperature."""
+        model = factory()
+        dq_cold = model.update_capacity(_make_state(T=10.0), dt=86400.0, accumulated_qloss=0.0)
+        dq_hot = model.update_capacity(_make_state(T=45.0), dt=86400.0, accumulated_qloss=0.0)
+        assert dq_hot > dq_cold
+
+    @pytest.mark.parametrize("factory", GASPER_CALENDAR_FACTORIES, ids=lambda f: f.__name__)
+    def test_continuity_under_subdivision(self, factory):
+        """Virtual-time continuation: 100 small steps ≈ 1 big step."""
+        state = _make_state(soc=0.5, T=25.0)
+        total_time = 86400.0  # 1 day
+
+        dq_single = factory().update_capacity(state, dt=total_time, accumulated_qloss=0.0)
+
+        model = factory()
+        accumulated = 0.0
+        n_steps = 100
+        for _ in range(n_steps):
+            dq = model.update_capacity(state, dt=total_time / n_steps, accumulated_qloss=accumulated)
+            accumulated += dq
+
+        assert accumulated == pytest.approx(dq_single, rel=0.02)
+
+    @pytest.mark.parametrize("factory", GASPER_CALENDAR_FACTORIES, ids=lambda f: f.__name__)
+    def test_one_year_in_sensible_range(self, factory):
+        """At 25 °C and 50 % SOC, 1 year of calendar aging should land in
+        the 0.1 %–15 % capacity-loss band typical of high-quality cells.
+        Cheap sanity check that the model + scale factors are wired up.
+        """
+        model = factory()
+        state = _make_state(soc=0.5, T=25.0)
+        dq = model.update_capacity(state, dt=365 * 86400.0, accumulated_qloss=0.0)
+        assert 1e-3 < dq < 0.15, f"{factory.__name__} 1y qloss={dq:.4f} outside plausible band"
+
+
+class TestGasperCyclicFamily:
+    @pytest.mark.parametrize("factory", GASPER_CYCLIC_FACTORIES, ids=lambda f: f.__name__)
+    def test_resistance_returns_zero(self, factory):
+        """Gasper models intentionally do not model resistance increase."""
+        model = factory()
+        assert model.update_resistance(_make_state(), _make_half_cycle()) == 0.0
+
+    @pytest.mark.parametrize("factory", GASPER_CYCLIC_FACTORIES, ids=lambda f: f.__name__)
+    def test_continuity_under_subdivision(self, factory):
+        """Virtual-FEC continuation: many small cycles ≈ one big cycle.
+
+        Splits a single full-equivalent cycle into 100 micro-cycles with
+        identical stress factors. The accumulated qloss must match the
+        single-shot result up to the expected continuation tolerance.
+        """
+        state = _make_state(soc=0.5, T=25.0)
+        total_fec = 1.0
+
+        hc_single = HalfCycle(depth_of_discharge=0.5, mean_soc=0.5, c_rate=0.5, full_equivalent_cycles=total_fec)
+        dq_single = factory().update_capacity(state, hc_single, accumulated_qloss=0.0)
+
+        model = factory()
+        accumulated = 0.0
+        n_steps = 100
+        for _ in range(n_steps):
+            hc = HalfCycle(
+                depth_of_discharge=0.5,
+                mean_soc=0.5,
+                c_rate=0.5,
+                full_equivalent_cycles=total_fec / n_steps,
+            )
+            dq = model.update_capacity(state, hc, accumulated_qloss=accumulated)
+            accumulated += dq
+
+        assert accumulated == pytest.approx(dq_single, rel=0.02)


### PR DESCRIPTION
A large-format prismatic LFP capacity-fade model from Gasper et al. 2023 ([*J. Energy Storage* 73, 109042](https://doi.org/10.1016/j.est.2023.109042)), ported one-to-one from NREL's [BLAST-Lite](https://github.com/NREL/BLAST-Lite). Semi-empirical: an Arrhenius calendar term with anode-potential SoC dependence, and a low-order semi-empirical cyclic term. Behaves cleanly across the full DoD range (LFP chemistry is intrinsically DoD-insensitive in this fit).

A large-format pouch NMC capacity-fade model from the same Gasper et al. 2023 study. Compact single-term multiplicative power law in DoD, T, and C-rate. The simplest and best-behaved of the paper's four NMC chemistries.

!!! note "No resistance model"
    Gasper et al. 2023 publishes capacity-fade equations only.